### PR TITLE
Applied fix on Page when an invalid category is selected

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -78,7 +78,7 @@ class Page extends Content implements PageInterface, StorableInterface
         if (isset($this->page['category']) && $including_parents) {
             $category = Taxonomy::byName($this->page['category']);
 
-            if (!empty($category->fullUrl())) {
+            if (!is_null($category) && !empty($category->fullUrl())) {
                 $slug_prefix = "{$category->fullUrl()}/";
             }
         }

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -468,4 +468,25 @@ class PageTest extends TestCase
 
         $this->assertTrue($page->rawPostDate()->isSameDay($page->rawUpdatedDate()));
     }
+
+    public function test_page_with_invalid_taxonomy_returns_as_having_root_as_category()
+    {
+        Page::update(
+            Collection::make([
+                [
+                    'title' => 'Homepage title',
+                    'description' => 'Homepage description',
+                    'summary' => 'Homepage summary',
+                    'template_name' => 'template',
+                    'isPublished' => true,
+                    'isScheduled' => false,
+                    'filename' => 'testing.md',
+                    'postDate' => date('Y-m-d'),
+                    'category' => 'pages'
+                ]
+            ])
+        );
+
+        $this->assertSame('testing', Page::forSlug('testing')->slug(true));
+    }
 }


### PR DESCRIPTION
If a non-existing taxonomy was applied to a page, the slug including parent categories would return an error. This now returns the slug as if the page has "home" as taxonomy category.