### PR TITLE
Added better getters and setters

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -236,6 +236,21 @@ class Model implements ModelInterface, StorableInterface
     }
 
     /**
+     * Remove a key from the configuration
+     *
+     * @param string $key
+     * @return $this|ModelInterface
+     */
+    public function remove(string $key): ModelInterface
+    {
+        if ($this->has($key)) {
+            unset($this->matter[$key]);
+        }
+
+        return $this;
+    }
+
+    /**
      * Get the raw file body
      *
      * @return string

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -169,28 +169,68 @@ class Model implements ModelInterface, StorableInterface
     }
 
     /**
-     * Add data to the front matter
+     * Set a value on the specified key in the configuration
+     *
+     * Kept around for backward compatibility
      *
      * @param string $key
-     * @param mixed $value
+     * @param $value
      * @return ModelInterface
+     *
+     * @deprecated since 3.2.0
      */
     public function addMatter(string $key, $value): ModelInterface
     {
-        $this->matter[$key] = $value;
-
-        return $this;
+        return $this->set($key, $value);
     }
-
+    
     /**
-     * Set the front matter
+     * Set data in the front matter, but only for the keys specified in the input array
      *
      * @param array $matter
      * @return ModelInterface
      */
     public function setMatter(array $matter): ModelInterface
     {
-        $this->matter = $matter;
+        foreach (array_keys($matter) as $key) {
+            $this->matter[$key] = $matter[$key];
+        }
+
+        return $this;
+    }
+
+    /**
+     * Determine whether a key is present in the configuration
+     *
+     * @param string $key
+     * @return bool
+     */
+    public function has(string $key): bool
+    {
+        return isset($this->matter[$key]);
+    }
+
+    /**
+     * Get the value of the specified key, return null if it doesn't exist
+     *
+     * @param string $key
+     * @return mixed|null
+     */
+    public function get(string $key)
+    {
+        return $this->matter[$key] ?? null;
+    }
+
+    /**
+     * Set a value on the specified key in the configuration
+     *
+     * @param string $key
+     * @param $value
+     * @return $this|ModelInterface
+     */
+    public function set(string $key, $value): ModelInterface
+    {
+        $this->matter[$key] = $value;
 
         return $this;
     }
@@ -328,7 +368,7 @@ class Model implements ModelInterface, StorableInterface
      */
     public function __get($key)
     {
-        return $this->matter[$key] ?? null;
+        return $this->get($key);
     }
 
     /**

--- a/tests/Models/ArticleTest.php
+++ b/tests/Models/ArticleTest.php
@@ -326,6 +326,17 @@ This is a paragraph';
 
         $this->assertSame('Testing things', Article::find('testing')->title());
         $this->assertSame('Testing things', Article::find('testing')->title);
+
+        Article::find('testing')
+            ->remove('title')
+            ->setMatter([
+                'post_date' => date('Y-m-d'),
+                'is_scheduled' => true
+            ])
+            ->setBody('# Testing')
+            ->save();
+
+        $this->assertSame('Testing', Article::find('testing')->title());
     }
 
     public function test_article_can_be_removed_by_slug()

--- a/tests/Models/ArticleTest.php
+++ b/tests/Models/ArticleTest.php
@@ -326,16 +326,6 @@ This is a paragraph';
 
         $this->assertSame('Testing things', Article::find('testing')->title());
         $this->assertSame('Testing things', Article::find('testing')->title);
-
-        Article::find('testing')
-            ->setMatter([
-                'post_date' => date('Y-m-d'),
-                'is_scheduled' => true
-            ])
-            ->setBody('# Testing')
-            ->save();
-
-        $this->assertSame('Testing', Article::find('testing')->title());
     }
 
     public function test_article_can_be_removed_by_slug()

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace AloiaCms\Tests\Models;
 
 use AloiaCms\Models\Article;
@@ -19,7 +18,7 @@ class ModelTest extends TestCase
         $this->assertSame('title', $article->matter()['title']);
         $this->assertSame('description', $article->matter()['description']);
 
-        $article->addMatter('title', 'New title');
+        $article->set('title', 'New title');
 
         $this->assertSame('New title', $article->matter()['title']);
         $this->assertSame('description', $article->matter()['description']);
@@ -34,5 +33,30 @@ class ModelTest extends TestCase
             ]);
 
         $this->assertSame('testing', $article->filename());
+    }
+
+    public function test_value_can_be_set_on_model_instance()
+    {
+        $article = Article::find('testing')
+            ->set('title', 'Article title');
+
+        $this->assertSame('Article title', $article->get('title'));
+    }
+    
+    public function test_non_specified_configuration_attributes_are_not_overwritten()
+    {
+        $article = Article::find('testing')
+            ->setMatter([
+                'title' => 'Article title',
+                'description' => 'description'
+            ]);
+
+        $this->assertSame('Article title', $article->get('title'));
+        $this->assertSame('description', $article->get('description'));
+
+        $article->setMatter(['description' => 'Article description']);
+
+        $this->assertSame('Article title', $article->get('title'));
+        $this->assertSame('Article description', $article->get('description'));
     }
 }

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -59,4 +59,30 @@ class ModelTest extends TestCase
         $this->assertSame('Article title', $article->get('title'));
         $this->assertSame('Article description', $article->get('description'));
     }
+    
+    public function test_data_can_be_checked_for_existence()
+    {
+        $article = Article::find('testing')
+            ->setMatter([
+                'title' => 'Article title',
+                'description' => 'description',
+            ]);
+
+        $this->assertTrue($article->has('title'));
+        $this->assertFalse($article->has('summary'));
+
+        $article->remove('title');
+
+        $this->assertFalse($article->has('title'));
+    }
+    
+    public function test_add_matter_still_works_after_deprecation()
+    {
+        $article = Article::find('testing')
+            ->set('title', 'Article title')
+            ->addMatter('description', 'description');
+
+        $this->assertSame('Article title', $article->get('title'));
+        $this->assertSame('description', $article->get('description'));
+    }
 }


### PR DESCRIPTION
Added a fix for issue #19

This change introduces a backward compatible change in getting and setting data on models:

Changes:
- addMatter(string $key, $value) is deprecated and now calls set(string $key, $value) under the hood
- setMatter(array $matter) now won't overwrite data that wasn't provided in the input array. (example 1)
- __get(string $key) now calls get(string $key) under the hood, instead of directly accessing the matter array

Additions:
- Added has(string $key) method to check if data is present in the model.
- Added get(string $key) method as a cleaner way to get a single value from the model.
- Added set(string $key, $value) method as a better named alternative to addMatter().
- Added remove(string $key) method to remove a data key from the model.

**Example 1**
When you set initial values on a model:
```php
$article = Article::find('testing')
            ->setMatter([
                'title' => 'Article title',
                'description' => 'description'
            ]);
```
And then set some more data but with different keys:
```php
$article = Article::find('testing')
            ->setMatter([
                'summary' => 'Article summary',
                'description' => 'Article description'
            ]);
```
will now result in data that looks like this:

```php
[
    'title' => 'Article title',
    'description' => 'Article description',
    'summary' => 'Article summary'
]
```
instead of what it resulted in before this change:
```php
[
    'description' => 'Article description',
    'summary' => 'Article summary'
]
```
Only provided keys are overwritten.

