### PR TITLE
🧑‍💻 Improve compatibility with collection

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -627,4 +627,14 @@ class Model implements ModelInterface, StorableInterface, UrlRoutable
     {
         return $this->matter[$key] ?? $default;
     }
+
+    public function __isset($key)
+    {
+        return $this->has($key);
+    }
+
+    public function __unset($key)
+    {
+        return $this->remove($key);
+    }
 }


### PR DESCRIPTION
This PR aims to fix and improve the `Model`'s compatibility with Laravel's `Collection`.

Before, you'll have to give a closure to `Collection::where()`

```php
$articles->where(fn($article) => $article->is_published === true);
```

With this PR, you can conveniently filter just using the key.

```php
$articles->where('is_published');
```